### PR TITLE
fix: prevent duplicate Telegram notification on submitted article

### DIFF
--- a/app/Livewire/Components/Slideovers/ArticleForm.php
+++ b/app/Livewire/Components/Slideovers/ArticleForm.php
@@ -121,7 +121,7 @@ final class ArticleForm extends SlideOverComponent
             $article->tags()->sync($this->form->tags);
 
             Flux::toast(
-                text: $article->submitted_at
+                text: ! $wasAlreadySubmitted && $article->submitted_at
                     ? __('notifications.article.submitted')
                     : __('notifications.article.updated'),
                 variant: 'success'

--- a/app/Livewire/Components/Slideovers/ArticleForm.php
+++ b/app/Livewire/Components/Slideovers/ArticleForm.php
@@ -93,6 +93,8 @@ final class ArticleForm extends SlideOverComponent
 
         $this->form->validate();
 
+        $wasAlreadySubmitted = $this->article?->id && $this->article->isSubmitted();
+
         $publishedFields = [
             'published_at' => $this->form->published_at
                 ? Date::parse($this->form->published_at)
@@ -141,7 +143,7 @@ final class ArticleForm extends SlideOverComponent
             );
         }
 
-        if ($this->form->is_draft === false && ! $article->isApproved()) {
+        if (! $wasAlreadySubmitted && $this->form->is_draft === false && ! $article->isApproved()) {
             event(new ArticleWasSubmittedForApproval($article));
         }
 

--- a/tests/Feature/Livewire/Components/Slideovers/ArticleFormTest.php
+++ b/tests/Feature/Livewire/Components/Slideovers/ArticleFormTest.php
@@ -2,12 +2,63 @@
 
 declare(strict_types=1);
 
+use App\Events\ArticleWasSubmittedForApproval;
 use App\Livewire\Components\Slideovers\ArticleForm;
+use App\Models\Article;
+use App\Models\Tag;
+use App\Models\User;
+use Illuminate\Support\Facades\Event;
 use Livewire\Livewire;
 
 describe(ArticleForm::class, function (): void {
     it('return redirect to unauthenticated user', function (): void {
         Livewire::test(ArticleForm::class)
             ->assertStatus(302);
+    });
+
+    it('dispatches telegram notification only on first submission', function (): void {
+        Event::fake([ArticleWasSubmittedForApproval::class]);
+
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $tag = Tag::factory()->create(['concerns' => ['post']]);
+
+        Livewire::actingAs($user)
+            ->test(ArticleForm::class)
+            ->set('form.title', 'Mon premier article de test')
+            ->set('form.slug', 'mon-premier-article-de-test')
+            ->set('form.body', 'Contenu de mon article suffisamment long pour la validation')
+            ->set('form.locale', 'fr')
+            ->set('form.is_draft', false)
+            ->set('form.published_at', now()->format('Y-m-d'))
+            ->set('form.tags', [$tag->id])
+            ->call('save');
+
+        Event::assertDispatchedTimes(ArticleWasSubmittedForApproval::class, 1);
+    });
+
+    it('does not re-dispatch telegram notification when updating a submitted article', function (): void {
+        Event::fake([ArticleWasSubmittedForApproval::class]);
+
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $tag = Tag::factory()->create(['concerns' => ['post']]);
+        $article = Article::factory()->create([
+            'user_id' => $user->id,
+            'submitted_at' => now(),
+            'published_at' => now(),
+        ]);
+        $article->tags()->sync([$tag->id]);
+
+        Livewire::actingAs($user)
+            ->test(ArticleForm::class, ['articleId' => $article->id])
+            ->set('form.title', 'Titre modifié de mon article')
+            ->set('form.slug', $article->slug)
+            ->set('form.body', 'Contenu modifié de mon article suffisamment long')
+            ->set('form.locale', 'fr')
+            ->set('form.is_draft', false)
+            ->set('form.published_at', now()->format('Y-m-d'))
+            ->set('form.tags', [$tag->id])
+            ->call('save');
+
+        Event::assertNotDispatched(ArticleWasSubmittedForApproval::class);
     });
 })->group('articles');


### PR DESCRIPTION
## Summary

- Prevent `ArticleWasSubmittedForApproval` event from being dispatched multiple times when a user edits an already-submitted article
- Show the correct toast message ("article updated" instead of "article submitted") when updating a published article

## Cause

The event dispatch and toast condition in `ArticleForm::save()` only checked `is_draft === false && !isApproved()`, which was true on every save of a submitted-but-not-yet-approved article — causing duplicate Telegram notifications (4-5x observed).

## Fix

Capture `$wasAlreadySubmitted` before the save operation and use it to gate both the event dispatch and the toast message.