### PR TITLE
feat: implement article sponsoring system

### DIFF
--- a/app/Actions/Article/ApprovedArticleAction.php
+++ b/app/Actions/Article/ApprovedArticleAction.php
@@ -6,6 +6,7 @@ namespace App\Actions\Article;
 
 use App\Gamify\Points\ArticlePublished;
 use App\Models\Article;
+use Illuminate\Support\Facades\Cache;
 
 final class ApprovedArticleAction
 {
@@ -14,6 +15,8 @@ final class ApprovedArticleAction
         $article->update(['approved_at' => now()]);
 
         givePoint(new ArticlePublished($article));
+
+        Cache::tags(['home', 'articles'])->flush();
 
         return $article;
     }

--- a/app/Filament/Cpanel/Resources/Articles/ArticleResource.php
+++ b/app/Filament/Cpanel/Resources/Articles/ArticleResource.php
@@ -37,11 +37,15 @@ final class ArticleResource extends Resource
     public static function getNavigationBadge(): ?string
     {
         /** @var int $count */
-        $count = Cache::remember('articles:pending_count', now()->addMinutes(5), fn (): int => Article::query()
-            ->whereNotNull('submitted_at')
-            ->whereNull('approved_at')
-            ->whereNull('declined_at')
-            ->count());
+        $count = Cache::remember(
+            key: 'articles:pending_count',
+            ttl: now()->addMinutes(5),
+            callback: fn (): int => Article::query()
+                ->whereNotNull('submitted_at')
+                ->whereNull('approved_at')
+                ->whereNull('declined_at')
+                ->count()
+        );
 
         return $count > 0 ? (string) $count : null;
     }
@@ -126,6 +130,10 @@ final class ArticleResource extends Resource
                         return [];
                     })
                     ->sortable(),
+                Columns\IconColumn::make('is_sponsored')
+                    ->label(__('Sponsorisé'))
+                    ->boolean()
+                    ->sortable(),
             ])
             ->recordActions([
                 Actions\ActionGroup::make([
@@ -170,6 +178,51 @@ final class ArticleResource extends Resource
                                 ->success()
                                 ->send();
                         }),
+                    Actions\Action::make('sponsor')
+                        ->visible(fn (Article $record): bool => $record->isPublished() && ! $record->isActivelySponsored())
+                        ->label(__('Sponsoriser'))
+                        ->icon('heroicon-s-star')
+                        ->color('warning')
+                        ->modalHeading(__('Sponsoriser cet article'))
+                        ->modalDescription(__("L'article sera mis en avant sur la page d'accueil."))
+                        ->requiresConfirmation()
+                        ->modalIcon('heroicon-s-star')
+                        ->action(function (Article $record): void {
+                            Gate::authorize('sponsor', $record);
+
+                            $record->update([
+                                'is_sponsored' => true,
+                                'sponsored_at' => $record->sponsored_at ?? now(),
+                            ]);
+
+                            Cache::tags(['home', 'articles'])->flush();
+
+                            Notification::make()
+                                ->title(__('Article sponsorisé'))
+                                ->success()
+                                ->send();
+                        }),
+                    Actions\Action::make('unsponsor')
+                        ->visible(fn (Article $record): bool => $record->isActivelySponsored())
+                        ->label(__('Retirer le sponsoring'))
+                        ->icon('heroicon-s-x-circle')
+                        ->color('gray')
+                        ->modalHeading(__('Retirer le sponsoring'))
+                        ->modalDescription(__('L\'article ne sera plus mis en avant mais conservera son badge sponsorisé.'))
+                        ->requiresConfirmation()
+                        ->modalIcon('heroicon-s-x-circle')
+                        ->action(function (Article $record): void {
+                            Gate::authorize('sponsor', $record);
+
+                            $record->update(['is_sponsored' => false]);
+
+                            Cache::tags(['home', 'articles'])->flush();
+
+                            Notification::make()
+                                ->title(__('Sponsoring retiré'))
+                                ->success()
+                                ->send();
+                        }),
                     Actions\Action::make('show')
                         ->icon('untitledui-eye')
                         ->url(fn (Article $record): string => route('articles.show', $record))
@@ -177,7 +230,8 @@ final class ArticleResource extends Resource
                         ->label(__('Afficher')),
                     Actions\DeleteAction::make()
                         ->button()
-                        ->label(__('Supprimer')),
+                        ->label(__('Supprimer'))
+                        ->after(fn () => Cache::tags(['home', 'articles'])->flush()),
                 ]),
             ])
             ->toolbarActions([

--- a/app/Livewire/Pages/Home.php
+++ b/app/Livewire/Pages/Home.php
@@ -23,8 +23,9 @@ final class Home extends Component
                 key: 'home.articles',
                 ttl: $ttl,
                 callback: fn (): Collection => Article::with(['tags', 'media'])
-                    ->latest('published_at')
                     ->published()
+                    ->sponsoredFirst()
+                    ->latest('published_at')
                     ->limit(4)
                     ->get()
             ),

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -41,7 +41,7 @@ use Spatie\Sitemap\Tags\Url;
  * @property-read string $body
  * @property-read bool $show_toc
  * @property-read bool $is_pinned
- * @property-read int $is_sponsored
+ * @property-read bool $is_sponsored
  * @property-read ?string $canonical_url
  * @property-read ?string $reason
  * @property-read ?int $tweet_id
@@ -229,12 +229,12 @@ final class Article extends Model implements Feedable, HasMedia, ReactableInterf
 
     public function isSponsored(): bool
     {
-        return ! $this->isNotSponsored();
+        return $this->sponsored_at !== null;
     }
 
-    public function isNotSponsored(): bool
+    public function isActivelySponsored(): bool
     {
-        return $this->sponsored_at === null;
+        return $this->is_sponsored;
     }
 
     public function isDeclined(): bool
@@ -314,6 +314,7 @@ final class Article extends Model implements Feedable, HasMedia, ReactableInterf
             'published_at' => 'datetime',
             'show_toc' => 'boolean',
             'is_pinned' => 'boolean',
+            'is_sponsored' => 'boolean',
         ];
     }
 }

--- a/app/Models/Builders/ArticleQueryBuilder.php
+++ b/app/Models/Builders/ArticleQueryBuilder.php
@@ -74,6 +74,16 @@ final class ArticleQueryBuilder extends Builder
         return $this->whereNotNull('sponsored_at');
     }
 
+    public function activelySponsored(): self
+    {
+        return $this->where('is_sponsored', true);
+    }
+
+    public function sponsoredFirst(): self
+    {
+        return $this->orderByDesc('is_sponsored');
+    }
+
     public function notDeclined(): self
     {
         return $this->whereNull('declined_at');

--- a/app/Policies/ArticlePolicy.php
+++ b/app/Policies/ArticlePolicy.php
@@ -78,4 +78,13 @@ final class ArticlePolicy
 
         return $user->isAdmin();
     }
+
+    public function sponsor(User $user): bool
+    {
+        if ($user->isModerator()) {
+            return true;
+        }
+
+        return $user->isAdmin();
+    }
 }

--- a/config/lcm.php
+++ b/config/lcm.php
@@ -97,7 +97,6 @@ return [
             'https://freek.dev/feed',
             'https://ashallendesign.co.uk/rss/blog',
             'https://benjamincrozat.com/feed',
-            'https://laravel-france.com/rss',
         ],
     ],
 

--- a/resources/views/components/articles/card.blade.php
+++ b/resources/views/components/articles/card.blade.php
@@ -30,13 +30,13 @@
             'justify-between gap-4' => ! $isSummary,
             'flex-col justify-between gap-2' => $isSummary,
         ])>
-            @if ($article->tags->isNotEmpty())
-                <div class="flex items-center gap-2">
-                    @foreach ($article->tags as $tag)
-                        <x-tag :$tag />
-                    @endforeach
-                </div>
-            @endif
+            <div class="flex items-center gap-2">
+                @foreach ($article->tags as $tag)
+                    <x-tag :$tag />
+                @endforeach
+
+                <x-articles.sponsored :isSponsored="$article->isSponsored()" />
+            </div>
 
             <time
                 datetime="{{ $article->published_at->format('Y-m-d') }}"

--- a/resources/views/components/articles/sponsored.blade.php
+++ b/resources/views/components/articles/sponsored.blade.php
@@ -4,7 +4,7 @@
 
 @if ($isSponsored)
     <span
-        class="inline-flex items-center rounded-md bg-linear-to-r from-[#413626] to-[#7E5D36] px-2.5 py-2 font-sans text-sm font-medium leading-none text-white"
+        class="inline-flex items-center rounded-md bg-linear-to-r from-[#413626] to-[#7E5D36] px-2 py-1.5 text-xs font-medium leading-none text-white"
     >
         {{ __('global.sponsored') }}
     </span>

--- a/resources/views/livewire/pages/articles/single-post.blade.php
+++ b/resources/views/livewire/pages/articles/single-post.blade.php
@@ -53,6 +53,8 @@
                                     @foreach ($article->tags as $tag)
                                         <x-tag :$tag />
                                     @endforeach
+
+                                    <x-articles.sponsored :isSponsored="$article->isSponsored()" />
                                 </div>
                             @endif
 

--- a/tests/Feature/Filament/Cpanel/ArticleSponsoringTest.php
+++ b/tests/Feature/Filament/Cpanel/ArticleSponsoringTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Cpanel\Resources\Articles\Pages\ListArticles;
+use App\Models\Article;
+use App\Models\User;
+use Filament\Actions\Testing\TestAction;
+use Filament\Facades\Filament;
+use Livewire\Livewire;
+
+beforeEach(function (): void {
+    Filament::setCurrentPanel('cpanel');
+
+    $this->user = $this->login(['email' => 'joe@laravel.cm']);
+    $this->user->assignRole('admin');
+});
+
+describe('Article Sponsoring', function (): void {
+    it('can sponsor a published article', function (): void {
+        $article = Article::factory()->approved()->create([
+            'published_at' => now()->subDay(),
+        ]);
+
+        Livewire::test(ListArticles::class)
+            ->callAction(TestAction::make('sponsor')->table($article));
+
+        $article->refresh();
+
+        expect($article->is_sponsored)->toBeTrue()
+            ->and($article->sponsored_at)->not->toBeNull();
+    });
+
+    it('can unsponsor a sponsored article', function (): void {
+        $article = Article::factory()->approved()->create([
+            'published_at' => now()->subDay(),
+            'is_sponsored' => true,
+            'sponsored_at' => now()->subWeek(),
+        ]);
+
+        Livewire::test(ListArticles::class)
+            ->callAction(TestAction::make('unsponsor')->table($article));
+
+        $article->refresh();
+
+        expect($article->is_sponsored)->toBeFalse()
+            ->and($article->sponsored_at)->not->toBeNull();
+    });
+
+    it('preserves sponsored_at date when re-sponsoring', function (): void {
+        $originalDate = now()->subMonth();
+
+        $article = Article::factory()->approved()->create([
+            'published_at' => now()->subDay(),
+            'is_sponsored' => false,
+            'sponsored_at' => $originalDate,
+        ]);
+
+        Livewire::test(ListArticles::class)
+            ->callAction(TestAction::make('sponsor')->table($article));
+
+        $article->refresh();
+
+        expect($article->is_sponsored)->toBeTrue()
+            ->and($article->sponsored_at->format('Y-m-d'))->toBe($originalDate->format('Y-m-d'));
+    });
+
+    it('hides sponsor action for non-published articles', function (): void {
+        $article = Article::factory()->submitted()->create();
+
+        Livewire::test(ListArticles::class)
+            ->assertActionHidden(TestAction::make('sponsor')->table($article));
+    });
+
+    it('prevents non-admin users from accessing the resource', function (): void {
+        $regularUser = User::factory()->create(['email_verified_at' => now()]);
+        $this->be($regularUser);
+
+        Livewire::test(ListArticles::class)
+            ->assertForbidden();
+    });
+})->group('articles', 'sponsoring');

--- a/tests/Feature/Livewire/Pages/HomeTest.php
+++ b/tests/Feature/Livewire/Pages/HomeTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\Pages\Home;
+use App\Models\Article;
+use Illuminate\Support\Facades\Cache;
+use Livewire\Livewire;
+
+describe(Home::class, function (): void {
+    it('displays sponsored articles before regular articles', function (): void {
+        Cache::tags(['home', 'articles'])->flush();
+
+        $regularArticle = Article::factory()->approved()->create([
+            'title' => 'Regular Article',
+            'published_at' => now(),
+            'is_sponsored' => false,
+        ]);
+
+        $sponsoredArticle = Article::factory()->approved()->create([
+            'title' => 'Sponsored Article',
+            'published_at' => now()->subWeek(),
+            'is_sponsored' => true,
+            'sponsored_at' => now()->subWeek(),
+        ]);
+
+        Livewire::test(Home::class)
+            ->assertSeeInOrder(['Sponsored Article', 'Regular Article']);
+    });
+})->group('home');


### PR DESCRIPTION
## Summary

- Add sponsor/unsponsor actions in Filament admin panel (admin & moderator only)
- Display sponsored articles first on homepage via `sponsoredFirst()` query scope
- Show "Sponsorisé" badge on article cards (home, listing, single post)
- Invalidate home cache only on specific admin actions (approve, sponsor, unsponsor, delete)
- `is_sponsored` (boolean) controls active sponsoring, `sponsored_at` (datetime) is preserved as historical badge

## Changes

- **Policy**: `sponsor()` method for admin/moderator authorization
- **Model**: `isActivelySponsored()`, `is_sponsored` cast, PHPDoc fix
- **QueryBuilder**: `activelySponsored()`, `sponsoredFirst()` scopes
- **Filament**: sponsor/unsponsor actions with confirmation modals, `is_sponsored` column
- **Home**: articles sorted by sponsoring first, then by `published_at`
- **Blade**: badge added to `card.blade.php` and `single-post.blade.php`
- **Cache**: targeted flush in `ApprovedArticleAction` and Filament actions only