### PR TITLE
hotfix: restore article covers by checking webp conversion existence

### DIFF
--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -199,9 +199,11 @@ final class Article extends Model implements Feedable, HasMedia, ReactableInterf
             return '';
         }
 
-        $webpUrl = $media->getUrl('webp');
+        if ($media->hasGeneratedConversion('webp')) {
+            return $media->getUrl('webp');
+        }
 
-        return $webpUrl !== '' ? $webpUrl : $media->getUrl();
+        return $media->getUrl();
     }
 
     public function excerpt(int $limit = 110): string


### PR DESCRIPTION
## Summary

Production hotfix — all article covers broke after v3.6.0 deploy because `getCoverImageUrl()` blindly returned a WebP URL for every media, even when the conversion did not exist on S3 yet.

`$media->getUrl('webp')` in Spatie only **builds a URL from a naming pattern** — it never checks if the file is actually on disk. Result: pointers to missing S3 objects → Scaleway returned `AccessDenied` on every article card and page.

## Fix

Use `$media->hasGeneratedConversion('webp')` which reads the `generated_conversions` JSON column on the `media` table. Spatie only flips that flag to `true` **after** a conversion job completes successfully, so the helper now:

- returns the WebP URL only when the conversion is confirmed generated
- falls back to the original image URL otherwise (pending queue, failed conversion, older articles not yet regenerated)

## Additional context

Nightwatch also reported `Spatie\Image\Exceptions\CouldNotLoadImage` with a `libpng iCCP: known incorrect sRGB profile` warning on some PNGs — those conversions fail silently in the queue. With this fix, failed conversions no longer break the UI; they simply keep serving the original image until reprocessed.

## Impact

- No migration needed
- No data change
- Deploy restores all article covers immediately on production