### PR TITLE
feat: add public changelog page

### DIFF
--- a/app/Actions/AbstractGithubApiAction.php
+++ b/app/Actions/AbstractGithubApiAction.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+abstract class AbstractGithubApiAction
+{
+    abstract protected function endpoint(): string;
+
+    /**
+     * @return array<string, int|string>
+     */
+    abstract protected function queryParameters(): array;
+
+    abstract protected function errorLogPrefix(): string;
+
+    /**
+     * @return array<int, array<string, mixed>>|null
+     */
+    protected function fetch(): ?array
+    {
+        /** @var string|null $token */
+        $token = config('services.github.token');
+
+        try {
+            /** @var Response $response */
+            $response = Http::when(
+                filled($token),
+                fn ($http) => $http->withToken($token), // @phpstan-ignore-line
+            )
+                ->acceptJson()
+                ->timeout(5)
+                ->retry(2, 200, throw: false)
+                ->get($this->endpoint(), $this->queryParameters());
+        } catch (ConnectionException) {
+            Log::warning($this->errorLogPrefix().': connection error');
+
+            return null;
+        } catch (Throwable $exception) {
+            Log::warning($this->errorLogPrefix(), ['class' => $exception::class]);
+
+            return null;
+        }
+
+        if ($response->failed()) {
+            Log::warning($this->errorLogPrefix().': non-2xx response', ['status' => $response->status()]);
+
+            return null;
+        }
+
+        /** @var array<int, array<string, mixed>> $payload */
+        $payload = $response->json();
+
+        return $payload;
+    }
+}

--- a/app/Actions/GetGithubContributorsAction.php
+++ b/app/Actions/GetGithubContributorsAction.php
@@ -80,7 +80,8 @@ final class GetGithubContributorsAction
         $payload = $response->json();
 
         return collect($payload)
-            ->filter(fn (array $contributor): bool => isset($contributor['login'])
+            ->filter(
+                fn (array $contributor): bool => isset($contributor['login'])
                 && $contributor['login'] !== ''
                 && ! in_array(mb_strtolower($contributor['login']), self::EXCLUDED_CONTRIBUTORS, true),
             )

--- a/app/Actions/GetGithubContributorsAction.php
+++ b/app/Actions/GetGithubContributorsAction.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Data\ContributorData;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+final class GetGithubContributorsAction
+{
+    private const string CACHE_KEY = 'github-contributors.v1';
+
+    private const string ENDPOINT = 'https://api.github.com/repos/laravelcm/laravel.cm/contributors';
+
+    private const int MAX_CONTRIBUTORS = 100;
+
+    private const array EXCLUDED_CONTRIBUTORS = [
+        'dependabot',
+        'dependabot[bot]',
+        'github-actions',
+        'github-actions[bot]',
+        'dependabot-preview',
+    ];
+
+    /**
+     * @return Collection<int, ContributorData>
+     */
+    public function __invoke(): Collection
+    {
+        /** @var Collection<int, ContributorData> */
+        return Cache::flexible(
+            key: self::CACHE_KEY,
+            ttl: [now()->addDays(7), now()->addDays(14)],
+            callback: fn (): Collection => $this->fetch(),
+        );
+    }
+
+    /**
+     * @return Collection<int, ContributorData>
+     */
+    private function fetch(): Collection
+    {
+        /** @var string|null $token */
+        $token = config('services.github.token');
+
+        try {
+            /** @var Response $response */
+            $response = Http::when(
+                filled($token),
+                fn ($http) => $http->withToken($token), // @phpstan-ignore-line
+            )
+                ->acceptJson()
+                ->timeout(5)
+                ->retry(2, 200, throw: false)
+                ->get(self::ENDPOINT, ['per_page' => self::MAX_CONTRIBUTORS]);
+        } catch (ConnectionException) {
+            Log::warning('Github contributors fetch failed: connection error');
+
+            return collect();
+        } catch (Throwable $exception) {
+            Log::warning('Github contributors fetch failed', ['class' => $exception::class]);
+
+            return collect();
+        }
+
+        if ($response->failed()) {
+            Log::warning('Github contributors fetch returned non-2xx', ['status' => $response->status()]);
+
+            return collect();
+        }
+
+        /** @var array<int, array{login?: string, avatar_url?: string}> $payload */
+        $payload = $response->json();
+
+        return collect($payload)
+            ->filter(fn (array $contributor): bool => isset($contributor['login'])
+                && $contributor['login'] !== ''
+                && ! in_array(mb_strtolower($contributor['login']), self::EXCLUDED_CONTRIBUTORS, true),
+            )
+            ->map(function (array $contributor): ContributorData {
+                /** @var array{login: string, avatar_url: string} $contributor */
+                return new ContributorData(
+                    login: $contributor['login'],
+                    avatar: 'https://unavatar.io/github/'.$contributor['login'],
+                );
+            })
+            ->values();
+    }
+}

--- a/app/Actions/GetGithubContributorsAction.php
+++ b/app/Actions/GetGithubContributorsAction.php
@@ -5,19 +5,12 @@ declare(strict_types=1);
 namespace App\Actions;
 
 use App\Data\ContributorData;
-use Illuminate\Http\Client\ConnectionException;
-use Illuminate\Http\Client\Response;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\Log;
-use Throwable;
 
-final class GetGithubContributorsAction
+final class GetGithubContributorsAction extends AbstractGithubApiAction
 {
-    private const string CACHE_KEY = 'github-contributors.v1';
-
-    private const string ENDPOINT = 'https://api.github.com/repos/laravelcm/laravel.cm/contributors';
+    private const string CACHE_KEY = 'github-contributors.v2';
 
     private const int MAX_CONTRIBUTORS = 100;
 
@@ -38,47 +31,40 @@ final class GetGithubContributorsAction
         return Cache::flexible(
             key: self::CACHE_KEY,
             ttl: [now()->addDays(7), now()->addDays(14)],
-            callback: fn (): Collection => $this->fetch(),
+            callback: fn (): Collection => $this->collect(),
         );
+    }
+
+    protected function endpoint(): string
+    {
+        return 'https://api.github.com/repos/laravelcm/laravel.cm/contributors';
+    }
+
+    /**
+     * @return array<string, int|string>
+     */
+    protected function queryParameters(): array
+    {
+        return ['per_page' => self::MAX_CONTRIBUTORS];
+    }
+
+    protected function errorLogPrefix(): string
+    {
+        return 'Github contributors fetch failed';
     }
 
     /**
      * @return Collection<int, ContributorData>
      */
-    private function fetch(): Collection
+    private function collect(): Collection
     {
-        /** @var string|null $token */
-        $token = config('services.github.token');
+        $payload = $this->fetch();
 
-        try {
-            /** @var Response $response */
-            $response = Http::when(
-                filled($token),
-                fn ($http) => $http->withToken($token), // @phpstan-ignore-line
-            )
-                ->acceptJson()
-                ->timeout(5)
-                ->retry(2, 200, throw: false)
-                ->get(self::ENDPOINT, ['per_page' => self::MAX_CONTRIBUTORS]);
-        } catch (ConnectionException) {
-            Log::warning('Github contributors fetch failed: connection error');
-
-            return collect();
-        } catch (Throwable $exception) {
-            Log::warning('Github contributors fetch failed', ['class' => $exception::class]);
-
-            return collect();
-        }
-
-        if ($response->failed()) {
-            Log::warning('Github contributors fetch returned non-2xx', ['status' => $response->status()]);
-
+        if ($payload === null) {
             return collect();
         }
 
         /** @var array<int, array{login?: string, avatar_url?: string}> $payload */
-        $payload = $response->json();
-
         return collect($payload)
             ->filter(
                 fn (array $contributor): bool => isset($contributor['login'])
@@ -89,7 +75,7 @@ final class GetGithubContributorsAction
                 /** @var array{login: string, avatar_url: string} $contributor */
                 return new ContributorData(
                     login: $contributor['login'],
-                    avatar: 'https://unavatar.io/github/'.$contributor['login'],
+                    avatar: $contributor['avatar_url'],
                 );
             })
             ->values();

--- a/app/Actions/GetGithubReleasesAction.php
+++ b/app/Actions/GetGithubReleasesAction.php
@@ -7,20 +7,13 @@ namespace App\Actions;
 use App\Data\ContributorData;
 use App\Data\ReleaseAuthorData;
 use App\Data\ReleaseData;
-use Illuminate\Http\Client\ConnectionException;
-use Illuminate\Http\Client\Response;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Date;
-use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\Log;
-use Throwable;
 
-final class GetGithubReleasesAction
+final class GetGithubReleasesAction extends AbstractGithubApiAction
 {
-    private const string CACHE_KEY = 'github-releases';
-
-    private const string ENDPOINT = 'https://api.github.com/repos/laravelcm/laravel.cm/releases';
+    private const string CACHE_KEY = 'github-releases.v2';
 
     private const int MAX_RELEASES = 10;
 
@@ -39,46 +32,38 @@ final class GetGithubReleasesAction
         return Cache::flexible(
             key: self::CACHE_KEY,
             ttl: [now()->addDays(3), now()->addDays(5)],
-            callback: fn (): Collection => $this->fetch(),
+            callback: fn (): Collection => $this->collect(),
         );
+    }
+
+    protected function endpoint(): string
+    {
+        return 'https://api.github.com/repos/laravelcm/laravel.cm/releases';
+    }
+
+    /**
+     * @return array<string, int|string>
+     */
+    protected function queryParameters(): array
+    {
+        return ['per_page' => self::MAX_RELEASES];
+    }
+
+    protected function errorLogPrefix(): string
+    {
+        return 'Github releases fetch failed';
     }
 
     /**
      * @return Collection<int, ReleaseData>
      */
-    private function fetch(): Collection
+    private function collect(): Collection
     {
-        /** @var string|null $token */
-        $token = config('services.github.token');
+        $payload = $this->fetch();
 
-        try {
-            /** @var Response $response */
-            $response = Http::when(
-                filled($token),
-                fn ($http) => $http->withToken($token), // @phpstan-ignore-line
-            )
-                ->acceptJson()
-                ->timeout(5)
-                ->retry(2, 200, throw: false)
-                ->get(self::ENDPOINT, ['per_page' => self::MAX_RELEASES]);
-        } catch (ConnectionException) {
-            Log::warning('Github releases fetch failed: connection error');
-
-            return collect();
-        } catch (Throwable $exception) {
-            Log::warning('Github releases fetch failed', ['class' => $exception::class]);
-
+        if ($payload === null) {
             return collect();
         }
-
-        if ($response->failed()) {
-            Log::warning('Github releases fetch returned non-2xx', ['status' => $response->status()]);
-
-            return collect();
-        }
-
-        /** @var array<int, array<string, mixed>> $payload */
-        $payload = $response->json();
 
         return collect($payload)
             ->reject(fn (array $release): bool => (bool) ($release['draft'] ?? false))
@@ -118,7 +103,7 @@ final class GetGithubReleasesAction
         $contributors = collect([
             new ContributorData(
                 login: $author->login,
-                avatar: 'https://unavatar.io/github/'.$author->login,
+                avatar: $author->avatar_url,
             ),
         ]);
 
@@ -140,7 +125,7 @@ final class GetGithubReleasesAction
             $seen[] = $lower;
             $contributors->push(new ContributorData(
                 login: $login,
-                avatar: 'https://unavatar.io/github/'.$login,
+                avatar: "https://github.com/{$login}.png",
             ));
         }
 

--- a/app/Actions/GetGithubReleasesAction.php
+++ b/app/Actions/GetGithubReleasesAction.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Data\ContributorData;
+use App\Data\ReleaseAuthorData;
+use App\Data\ReleaseData;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+final class GetGithubReleasesAction
+{
+    private const string CACHE_KEY = 'github-releases';
+
+    private const string ENDPOINT = 'https://api.github.com/repos/laravelcm/laravel.cm/releases';
+
+    private const int MAX_RELEASES = 10;
+
+    private const array EXCLUDED_CONTRIBUTORS = [
+        'dependabot',
+        'github-actions',
+        'dependabot-preview',
+    ];
+
+    /**
+     * @return Collection<int, ReleaseData>
+     */
+    public function __invoke(): Collection
+    {
+        /** @var Collection<int, ReleaseData> */
+        return Cache::flexible(
+            key: self::CACHE_KEY,
+            ttl: [now()->addDays(3), now()->addDays(5)],
+            callback: fn (): Collection => $this->fetch(),
+        );
+    }
+
+    /**
+     * @return Collection<int, ReleaseData>
+     */
+    private function fetch(): Collection
+    {
+        /** @var string|null $token */
+        $token = config('services.github.token');
+
+        try {
+            /** @var Response $response */
+            $response = Http::when(
+                filled($token),
+                fn ($http) => $http->withToken($token), // @phpstan-ignore-line
+            )
+                ->acceptJson()
+                ->timeout(5)
+                ->retry(2, 200, throw: false)
+                ->get(self::ENDPOINT, ['per_page' => self::MAX_RELEASES]);
+        } catch (ConnectionException) {
+            Log::warning('Github releases fetch failed: connection error');
+
+            return collect();
+        } catch (Throwable $exception) {
+            Log::warning('Github releases fetch failed', ['class' => $exception::class]);
+
+            return collect();
+        }
+
+        if ($response->failed()) {
+            Log::warning('Github releases fetch returned non-2xx', ['status' => $response->status()]);
+
+            return collect();
+        }
+
+        /** @var array<int, array<string, mixed>> $payload */
+        $payload = $response->json();
+
+        return collect($payload)
+            ->reject(fn (array $release): bool => (bool) ($release['draft'] ?? false))
+            ->take(self::MAX_RELEASES)
+            ->map(function (array $release): ReleaseData {
+                /** @var array{tag_name: string, name: ?string, body: ?string, html_url: string, published_at: string, author: array{login: string, avatar_url: string, html_url: string}, prerelease?: bool} $release */
+                return $this->toReleaseData($release);
+            })
+            ->values();
+    }
+
+    /**
+     * @param  array{tag_name: string, name: ?string, body: ?string, html_url: string, published_at: string, author: array{login: string, avatar_url: string, html_url: string}, prerelease?: bool}  $release
+     */
+    private function toReleaseData(array $release): ReleaseData
+    {
+        $author = ReleaseAuthorData::from($release['author']);
+        $body = $release['body'] ?? '';
+
+        return new ReleaseData(
+            tag_name: $release['tag_name'],
+            name: $release['name'] ?? $release['tag_name'],
+            body: $body,
+            html_url: $release['html_url'],
+            published_at: Date::parse($release['published_at']),
+            author: $author,
+            contributors: $this->extractContributors($body, $author),
+            prerelease: $release['prerelease'] ?? false,
+        );
+    }
+
+    /**
+     * @return Collection<int, ContributorData>
+     */
+    private function extractContributors(string $body, ReleaseAuthorData $author): Collection
+    {
+        $contributors = collect([
+            new ContributorData(
+                login: $author->login,
+                avatar: 'https://unavatar.io/github/'.$author->login,
+            ),
+        ]);
+
+        preg_match_all('/@([\w-]+)\s+in\s+https:\/\/github\.com/', $body, $matches);
+
+        $seen = [mb_strtolower($author->login)];
+
+        foreach ($matches[1] as $login) {
+            $lower = mb_strtolower($login);
+
+            if (in_array($lower, $seen, true)) {
+                continue;
+            }
+
+            if (in_array($lower, self::EXCLUDED_CONTRIBUTORS, true)) {
+                continue;
+            }
+
+            $seen[] = $lower;
+            $contributors->push(new ContributorData(
+                login: $login,
+                avatar: 'https://unavatar.io/github/'.$login,
+            ));
+        }
+
+        return $contributors;
+    }
+}

--- a/app/Actions/GetGithubReleasesAction.php
+++ b/app/Actions/GetGithubReleasesAction.php
@@ -125,7 +125,7 @@ final class GetGithubReleasesAction extends AbstractGithubApiAction
             $seen[] = $lower;
             $contributors->push(new ContributorData(
                 login: $login,
-                avatar: "https://github.com/{$login}.png",
+                avatar: sprintf('https://github.com/%s.png', $login),
             ));
         }
 

--- a/app/Console/Commands/GenerateSitemap.php
+++ b/app/Console/Commands/GenerateSitemap.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Actions\GetGithubReleasesAction;
 use Illuminate\Console\Command;
 use Spatie\Sitemap\Sitemap;
 use Spatie\Sitemap\SitemapIndex;
@@ -15,8 +16,13 @@ final class GenerateSitemap extends Command
 
     protected $description = 'Generate the sitemap';
 
-    public function handle(): void
+    public function handle(GetGithubReleasesAction $getReleases): void
     {
+        $latestRelease = $getReleases()->first();
+        $changelogLastMod = $latestRelease !== null
+            ? $latestRelease->published_at
+            : now()->subMinutes(10);
+
         Sitemap::create()
             ->add(
                 Url::create(route('home'))
@@ -35,6 +41,12 @@ final class GenerateSitemap extends Command
                     ->setLastModificationDate(now()->subMinutes(10))
                     ->setChangeFrequency(Url::CHANGE_FREQUENCY_DAILY)
                     ->setPriority(0.5)
+            )
+            ->add(
+                Url::create(route('changelog'))
+                    ->setLastModificationDate($changelogLastMod)
+                    ->setChangeFrequency(Url::CHANGE_FREQUENCY_MONTHLY)
+                    ->setPriority(0.3)
             )
             ->writeToFile(public_path('sitemaps/base_sitemap.xml'));
 

--- a/app/Data/ContributorData.php
+++ b/app/Data/ContributorData.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data;
+
+use Spatie\LaravelData\Data;
+
+final class ContributorData extends Data
+{
+    public function __construct(
+        public string $login,
+        public string $avatar,
+    ) {}
+
+    public function profileUrl(): string
+    {
+        return 'https://github.com/'.$this->login;
+    }
+}

--- a/app/Data/ReleaseAuthorData.php
+++ b/app/Data/ReleaseAuthorData.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data;
+
+use Spatie\LaravelData\Data;
+
+final class ReleaseAuthorData extends Data
+{
+    public function __construct(
+        public string $login,
+        public string $avatar_url,
+        public string $html_url,
+    ) {}
+}

--- a/app/Data/ReleaseData.php
+++ b/app/Data/ReleaseData.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Data;
 
-use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use Illuminate\Support\Collection;
 use Spatie\LaravelData\Attributes\DataCollectionOf;
 use Spatie\LaravelData\Data;
@@ -19,7 +19,7 @@ final class ReleaseData extends Data
         public string $name,
         public string $body,
         public string $html_url,
-        public Carbon $published_at,
+        public CarbonInterface $published_at,
         public ReleaseAuthorData $author,
         #[DataCollectionOf(ContributorData::class)]
         public Collection $contributors,

--- a/app/Data/ReleaseData.php
+++ b/app/Data/ReleaseData.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data;
+
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Spatie\LaravelData\Attributes\DataCollectionOf;
+use Spatie\LaravelData\Data;
+
+final class ReleaseData extends Data
+{
+    /**
+     * @param  Collection<int, ContributorData>  $contributors
+     */
+    public function __construct(
+        public string $tag_name,
+        public string $name,
+        public string $body,
+        public string $html_url,
+        public Carbon $published_at,
+        public ReleaseAuthorData $author,
+        #[DataCollectionOf(ContributorData::class)]
+        public Collection $contributors,
+        public bool $prerelease = false,
+    ) {}
+}

--- a/app/Livewire/Components/ChangeLocale.php
+++ b/app/Livewire/Components/ChangeLocale.php
@@ -32,7 +32,7 @@ final class ChangeLocale extends Component
         app()->setLocale($locale);
         session()->put('locale', $locale);
 
-        $this->redirect(url()->previous(), navigate: true);
+        $this->redirect(safe_previous_url(), navigate: true);
     }
 
     #[Computed]

--- a/app/Livewire/Pages/Changelog.php
+++ b/app/Livewire/Pages/Changelog.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Pages;
+
+use App\Actions\GetGithubContributorsAction;
+use App\Actions\GetGithubReleasesAction;
+use App\Data\ContributorData;
+use App\Data\ReleaseData;
+use ArchTech\SEO\SEOManager;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Collection;
+use Livewire\Component;
+
+final class Changelog extends Component
+{
+    private const string REPOSITORY_URL = 'https://github.com/laravelcm/laravel.cm';
+
+    private GetGithubReleasesAction $getReleases;
+
+    private GetGithubContributorsAction $getContributors;
+
+    public function boot(GetGithubReleasesAction $getReleases, GetGithubContributorsAction $getContributors): void
+    {
+        $this->getReleases = $getReleases;
+        $this->getContributors = $getContributors;
+    }
+
+    public function mount(): void
+    {
+        /** @var SEOManager $seoManager */
+        $seoManager = seo();
+
+        $seoManager
+            ->title(__('pages/changelog.title'))
+            ->description(__('pages/changelog.description'))
+            ->url(route('changelog'));
+    }
+
+    public function render(): View
+    {
+        /** @var Collection<int, ReleaseData> $releases */
+        $releases = ($this->getReleases)();
+
+        /** @var Collection<int, ContributorData> $allContributors */
+        $allContributors = ($this->getContributors)();
+
+        return view('livewire.pages.changelog', [
+            'releases' => $releases,
+            'allContributors' => $allContributors,
+            'repositoryUrl' => self::REPOSITORY_URL,
+        ])->title(__('pages/changelog.title'));
+    }
+
+    public function renderBody(string $markdown): string
+    {
+        $html = (string) md_to_html($markdown);
+
+        $html = (string) preg_replace(
+            '/href=(["\'])\s*(?:javascript|data|vbscript):[^"\']*\1/i',
+            'href=$1#$1',
+            $html,
+        );
+
+        $html = (string) preg_replace_callback(
+            '/<a\s+([^>]*?)>/i',
+            static function (array $match): string {
+                $attributes = $match[1];
+
+                if (preg_match('/href=(["\'])(https?:\/\/[^"\']+)\1/i', $attributes) !== 1) {
+                    return $match[0];
+                }
+
+                if (preg_match('/\btarget=/i', $attributes) === 1 || preg_match('/\brel=/i', $attributes) === 1) {
+                    return $match[0];
+                }
+
+                return '<a '.mb_rtrim($attributes).' target="_blank" rel="noopener noreferrer nofollow">';
+            },
+            $html,
+        );
+
+        return (string) preg_replace(
+            '/(?<![\w\/])#(\d+)\b/',
+            '<a href="'.self::REPOSITORY_URL.'/pull/$1" target="_blank" rel="noopener noreferrer nofollow">#$1</a>',
+            $html,
+        );
+    }
+}

--- a/app/Livewire/Pages/Changelog.php
+++ b/app/Livewire/Pages/Changelog.php
@@ -8,6 +8,7 @@ use App\Actions\GetGithubContributorsAction;
 use App\Actions\GetGithubReleasesAction;
 use App\Data\ContributorData;
 use App\Data\ReleaseData;
+use App\Services\ReleaseBodyRenderer;
 use ArchTech\SEO\SEOManager;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Collection;
@@ -21,10 +22,13 @@ final class Changelog extends Component
 
     private GetGithubContributorsAction $getContributors;
 
+    private ReleaseBodyRenderer $bodyRenderer;
+
     public function boot(GetGithubReleasesAction $getReleases, GetGithubContributorsAction $getContributors): void
     {
         $this->getReleases = $getReleases;
         $this->getContributors = $getContributors;
+        $this->bodyRenderer = new ReleaseBodyRenderer(self::REPOSITORY_URL);
     }
 
     public function mount(): void
@@ -55,36 +59,6 @@ final class Changelog extends Component
 
     public function renderBody(string $markdown): string
     {
-        $html = (string) md_to_html($markdown);
-
-        $html = (string) preg_replace(
-            '/href=(["\'])\s*(?:javascript|data|vbscript):[^"\']*\1/i',
-            'href=$1#$1',
-            $html,
-        );
-
-        $html = (string) preg_replace_callback(
-            '/<a\s+([^>]*?)>/i',
-            static function (array $match): string {
-                $attributes = $match[1];
-
-                if (preg_match('/href=(["\'])(https?:\/\/[^"\']+)\1/i', $attributes) !== 1) {
-                    return $match[0];
-                }
-
-                if (preg_match('/\btarget=/i', $attributes) === 1 || preg_match('/\brel=/i', $attributes) === 1) {
-                    return $match[0];
-                }
-
-                return '<a '.mb_rtrim($attributes).' target="_blank" rel="noopener noreferrer nofollow">';
-            },
-            $html,
-        );
-
-        return (string) preg_replace(
-            '/(?<![\w\/])#(\d+)\b/',
-            '<a href="'.self::REPOSITORY_URL.'/pull/$1" target="_blank" rel="noopener noreferrer nofollow">#$1</a>',
-            $html,
-        );
+        return $this->bodyRenderer->render($markdown);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -182,8 +182,10 @@ final class AppServiceProvider extends ServiceProvider
         $manager->register(Commands\GoToForum::class);
         $manager->register(Commands\GoToDiscussions::class);
         $manager->register(Commands\ToggleTheme::class);
+        $manager->register(Commands\ToggleLocale::class);
         $manager->register(Commands\GoToHome::class);
         $manager->register(Commands\GoToAbout::class);
+        $manager->register(Commands\GoToChangelog::class);
         $manager->register(Commands\GoToRules::class);
     }
 }

--- a/app/Services/ReleaseBodyRenderer.php
+++ b/app/Services/ReleaseBodyRenderer.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+final class ReleaseBodyRenderer
+{
+    public function __construct(private readonly string $repositoryUrl) {}
+
+    public function render(string $markdown): string
+    {
+        $html = (string) md_to_html($markdown);
+
+        $html = $this->stripUnsafeSchemes($html);
+        $html = $this->enrichExternalLinks($html);
+
+        return $this->linkifyPullRequestReferences($html);
+    }
+
+    private function stripUnsafeSchemes(string $html): string
+    {
+        return (string) preg_replace(
+            '/href=(["\'])\s*(?:javascript|data|vbscript):[^"\']*\1/i',
+            'href=$1#$1',
+            $html,
+        );
+    }
+
+    private function enrichExternalLinks(string $html): string
+    {
+        return (string) preg_replace_callback(
+            '/<a\s+([^>]*?)>/i',
+            static function (array $match): string {
+                $attributes = $match[1];
+
+                if (preg_match('/href=(["\'])(https?:\/\/[^"\']+)\1/i', $attributes) !== 1) {
+                    return $match[0];
+                }
+
+                if (preg_match('/\btarget=/i', $attributes) === 1 || preg_match('/\brel=/i', $attributes) === 1) {
+                    return $match[0];
+                }
+
+                return '<a '.mb_rtrim($attributes).' target="_blank" rel="noopener noreferrer nofollow">';
+            },
+            $html,
+        );
+    }
+
+    private function linkifyPullRequestReferences(string $html): string
+    {
+        return (string) preg_replace(
+            '/(?<![\w\/])#(\d+)\b/',
+            '<a href="'.$this->repositoryUrl.'/pull/$1" target="_blank" rel="noopener noreferrer nofollow">#$1</a>',
+            $html,
+        );
+    }
+}

--- a/app/Spotlight/Commands/GoToChangelog.php
+++ b/app/Spotlight/Commands/GoToChangelog.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Spotlight\Commands;
+
+use App\Livewire\Components\Spotlight;
+use App\Spotlight\SpotlightCommand;
+
+final class GoToChangelog extends SpotlightCommand
+{
+    protected ?string $icon = 'heroicon-o-megaphone';
+
+    protected ?string $group = 'navigation';
+
+    protected array $synonyms = ['changelog', 'release', 'releases', 'mises à jour', 'nouveautés'];
+
+    public function getName(): string
+    {
+        return __('global.navigation.changelog');
+    }
+
+    public function execute(Spotlight $spotlight): void
+    {
+        $spotlight->redirect(route('changelog'), navigate: true);
+    }
+}

--- a/app/Spotlight/Commands/ToggleLocale.php
+++ b/app/Spotlight/Commands/ToggleLocale.php
@@ -36,6 +36,6 @@ final class ToggleLocale extends SpotlightCommand
         Auth::user()?->settings(['locale' => $newLocale]);
         session()->put('locale', $newLocale);
 
-        $spotlight->redirect(url()->previous(), navigate: true);
+        $spotlight->redirect(safe_previous_url(), navigate: true);
     }
 }

--- a/app/Spotlight/Commands/ToggleLocale.php
+++ b/app/Spotlight/Commands/ToggleLocale.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Spotlight\Commands;
+
+use App\Livewire\Components\Spotlight;
+use App\Spotlight\SpotlightCommand;
+use Illuminate\Support\Facades\Auth;
+
+final class ToggleLocale extends SpotlightCommand
+{
+    protected ?string $icon = 'heroicon-o-language';
+
+    protected ?string $group = 'commands';
+
+    protected array $synonyms = ['locale', 'language', 'langue', 'français', 'french', 'english', 'anglais'];
+
+    public function getName(): string
+    {
+        return __('command-palette.commands.toggle_locale');
+    }
+
+    public function execute(Spotlight $spotlight): void
+    {
+        /** @var array<int, string> $supportedLocales */
+        $supportedLocales = config('lcm.supported_locales', ['fr', 'en']);
+
+        $currentLocale = app()->getLocale();
+        $newLocale = $currentLocale === 'fr' ? 'en' : 'fr';
+
+        if (! in_array($newLocale, $supportedLocales, true)) {
+            return;
+        }
+
+        Auth::user()?->settings(['locale' => $newLocale]);
+        session()->put('locale', $newLocale);
+
+        $spotlight->redirect(url()->previous(), navigate: true);
+    }
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -118,3 +118,36 @@ if (! function_exists('isHolidayWeek')) {
         return $now->between($holidayStart, $holidayEnd);
     }
 }
+
+if (! function_exists('safe_previous_url')) {
+    /**
+     * Return the previous URL only when it belongs to the application host.
+     *
+     * `url()->previous()` falls back to the Referer header, which is client
+     * controlled. A crafted Referer could redirect users to an attacker site
+     * after an internal action (locale switch, form submit, ...). This helper
+     * guards against open-redirect attacks by enforcing a same-origin check,
+     * falling back to a safe URL when the previous location is off-site or
+     * unparseable.
+     */
+    function safe_previous_url(?string $fallback = null): string
+    {
+        $previous = url()->previous();
+        $fallback ??= route('home');
+
+        $appUrl = config('app.url');
+
+        if (! is_string($appUrl)) {
+            return $fallback;
+        }
+
+        $previousHost = parse_url($previous, PHP_URL_HOST);
+        $expectedHost = parse_url($appUrl, PHP_URL_HOST);
+
+        if (! is_string($previousHost) || ! is_string($expectedHost)) {
+            return $fallback;
+        }
+
+        return $previousHost === $expectedHost ? $previous : $fallback;
+    }
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -120,16 +120,6 @@ if (! function_exists('isHolidayWeek')) {
 }
 
 if (! function_exists('safe_previous_url')) {
-    /**
-     * Return the previous URL only when it belongs to the application host.
-     *
-     * `url()->previous()` falls back to the Referer header, which is client
-     * controlled. A crafted Referer could redirect users to an attacker site
-     * after an internal action (locale switch, form submit, ...). This helper
-     * guards against open-redirect attacks by enforcing a same-origin check,
-     * falling back to a safe URL when the previous location is off-site or
-     * unparseable.
-     */
     function safe_previous_url(?string $fallback = null): string
     {
         $previous = url()->previous();

--- a/lang/en/command-palette.php
+++ b/lang/en/command-palette.php
@@ -12,6 +12,7 @@ return [
 
     'commands' => [
         'toggle_theme' => 'Toggle theme',
+        'toggle_locale' => 'Switch language',
     ],
 
     'no_results' => 'No results found',

--- a/lang/en/global.php
+++ b/lang/en/global.php
@@ -16,6 +16,7 @@ return [
         'discussions' => 'Discussions',
         'community' => 'Community',
         'about' => 'About',
+        'changelog' => 'Changelog',
         'podcasts' => 'Podcasts',
         'jobs' => 'Jobs',
         'sponsors' => 'Sponsors',

--- a/lang/en/pages/changelog.php
+++ b/lang/en/pages/changelog.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'title' => 'Changelog',
+    'description' => 'All updates, new features and fixes shipped on Laravel Cameroun.',
+    'heading' => 'Product updates',
+    'subheading' => 'Latest changes to the platform, ship after ship.',
+    'published_on' => 'Published on :date',
+    'by' => 'by',
+    'empty' => 'No releases available yet.',
+    'contributors' => '{1} :count contributor|[2,*] :count contributors',
+    'all_contributors' => 'All contributors',
+    'all_contributors_description' => 'The people who have contributed to the Laravel Cameroun source code.',
+    'view_on_github' => 'View on GitHub',
+];

--- a/lang/fr/command-palette.php
+++ b/lang/fr/command-palette.php
@@ -12,6 +12,7 @@ return [
 
     'commands' => [
         'toggle_theme' => 'Changer le thème',
+        'toggle_locale' => 'Changer la langue',
     ],
 
     'no_results' => 'Aucun résultat trouvé',

--- a/lang/fr/global.php
+++ b/lang/fr/global.php
@@ -16,6 +16,7 @@ return [
         'discussions' => 'Discussions',
         'community' => 'Communauté',
         'about' => 'A propos',
+        'changelog' => 'Changelog',
         'podcasts' => 'Podcasts',
         'jobs' => 'Offres',
         'sponsors' => 'Sponsors',

--- a/lang/fr/pages/changelog.php
+++ b/lang/fr/pages/changelog.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'title' => 'Changelog',
+    'description' => 'Toutes les mises à jour, nouvelles fonctionnalités et corrections apportées à Laravel Cameroun.',
+    'heading' => 'Journal des mises à jour',
+    'subheading' => 'Les dernières nouveautés de la plateforme, ship après ship.',
+    'published_on' => 'Publié le :date',
+    'by' => 'par',
+    'empty' => 'Aucune release disponible pour le moment.',
+    'contributors' => '{1} :count contributeur|[2,*] :count contributeurs',
+    'all_contributors' => 'Tous les contributeurs',
+    'all_contributors_description' => 'Les personnes qui ont contribué au code source de Laravel Cameroun.',
+    'view_on_github' => 'Voir sur GitHub',
+];

--- a/resources/views/components/layouts/footer.blade.php
+++ b/resources/views/components/layouts/footer.blade.php
@@ -27,6 +27,7 @@
                     </h3>
                     <ul class="mt-6 space-y-3">
                         <x-footer-link :title="__('global.navigation.about')" :href="route('about')" />
+                        <x-footer-link :title="__('global.navigation.changelog')" :href="route('changelog')" />
                         <x-footer-link :title="__('global.navigation.sponsors')" :href="route('sponsors')" />
                         <x-footer-link
                             :title="__('global.navigation.branding')"

--- a/resources/views/livewire/pages/changelog.blade.php
+++ b/resources/views/livewire/pages/changelog.blade.php
@@ -1,0 +1,129 @@
+<div>
+    <x-container class="line-x px-0">
+        <header class="px-4 py-20 lg:py-28">
+            <div class="flex items-center gap-3">
+                <span class="inline-flex size-2 rounded-full bg-primary-500"></span>
+                <span class="font-mono text-xs uppercase tracking-widest text-primary-600 dark:text-primary-400">
+                    {{ __('pages/changelog.title') }}
+                </span>
+            </div>
+            <h1 class="mt-4 font-heading text-3xl font-bold tracking-tight text-gray-900 lg:text-5xl dark:text-white">
+                {{ __('pages/changelog.heading') }}
+            </h1>
+            <p class="mt-4 max-w-2xl text-base text-gray-600 lg:text-lg dark:text-gray-400">
+                {{ __('pages/changelog.subheading') }}
+            </p>
+        </header>
+
+        @if ($releases->isEmpty())
+            <div class="mx-4 rounded-lg border border-dashed border-gray-300 bg-white/60 p-12 text-center text-gray-600 backdrop-blur dark:border-gray-700 dark:bg-gray-900/60 dark:text-gray-400">
+                {{ __('pages/changelog.empty') }}
+            </div>
+        @else
+            <div class="pb-20 lg:grid lg:grid-cols-[1fr_260px] lg:gap-x-8 lg:pb-28">
+                <div class="px-4 space-y-16 lg:space-y-20">
+                    @foreach ($releases as $release)
+                        <section class="relative lg:grid lg:grid-cols-[140px_1fr] lg:gap-x-6">
+                            <div class="relative lg:sticky lg:top-28 lg:self-start">
+                                <span class="absolute top-1.5 z-10 size-2.5 -left-5.25 rounded-full bg-primary-500 ring-4 ring-gray-100 dark:ring-white/20"></span>
+                                <time
+                                    datetime="{{ $release->published_at->toIso8601String() }}"
+                                    class="text-sm text-gray-600 dark:text-gray-400"
+                                >
+                                    {{ $release->published_at->isoFormat('LL') }}
+                                </time>
+                            </div>
+
+                            <article id="{{ $release->tag_name }}" class="mt-6 scroll-mt-28 lg:mt-0">
+                                <div>
+                                    <a
+                                        href="{{ $release->html_url }}"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        class="inline-flex items-center rounded-md bg-primary-50 px-2 py-0.5 font-mono text-xs font-medium text-primary-700 ring-1 ring-primary-200/60 transition hover:bg-primary-100 dark:bg-primary-500/10 dark:text-primary-300 dark:ring-primary-500/30 dark:hover:bg-primary-500/20"
+                                    >
+                                        {{ $release->tag_name }}
+                                    </a>
+                                </div>
+
+                                <h2 class="mt-4 font-heading text-2xl font-bold tracking-tight text-gray-900 lg:text-4xl dark:text-white">
+                                    {{ $release->name }}
+                                </h2>
+
+                                <div class="prose prose-emerald mt-8 dark:prose-invert prose-headings:font-heading prose-headings:scroll-mt-28 prose-h2:text-xl prose-h3:text-lg prose-a:text-primary-600 dark:prose-a:text-primary-400">
+                                    {!! $this->renderBody($release->body) !!}
+                                </div>
+
+                                @if ($release->contributors->isNotEmpty())
+                                    <div class="mt-10 flex items-center gap-2.5">
+                                        <div class="flex -space-x-1.5">
+                                            @foreach ($release->contributors as $contributor)
+                                                <a
+                                                    href="{{ $contributor->profileUrl() }}"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    title="{{ '@' . $contributor->login }}"
+                                                >
+                                                    <img
+                                                        src="{{ $contributor->avatar }}"
+                                                        alt="{{ $contributor->login }}"
+                                                        loading="lazy"
+                                                        class="size-6 rounded-full ring-2 ring-white outline-2 outline-gray-200 dark:ring-gray-950 dark:outline-gray-800"
+                                                    />
+                                                </a>
+                                            @endforeach
+                                        </div>
+                                        @if ($release->contributors->count() > 1)
+                                            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                                                {{ trans_choice('pages/changelog.contributors', $release->contributors->count(), ['count' => $release->contributors->count()]) }}
+                                            </span>
+                                        @endif
+                                    </div>
+                                @endif
+                            </article>
+                        </section>
+                    @endforeach
+                </div>
+
+                @if ($allContributors->isNotEmpty())
+                    <aside class="mt-16 lg:mt-0 lg:sticky lg:top-28 lg:self-start">
+                        <div class="bg-white dark:bg-line-black border-t border-l border-line border-dotted">
+                            <div class="px-4 py-3  bg-gray-50 dark:bg-gray-950 flex items-start gap-4">
+                                <x-untitledui-code class="size-4 shrink-0 text-primary-600 dark:text-primary-500" aria-hidden="true" />
+                                <p class="text-gray-900 dark:text-white text-xs font-mono uppercase">
+                                    {{ __('pages/changelog.all_contributors') }}
+                                </p>
+                            </div>
+                            <div class="p-4">
+                                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                                    {{ __('pages/changelog.all_contributors_description') }}
+                                </p>
+                            </div>
+                            <div class="border-y border-line">
+                                <div class="flex flex-wrap gap-2 p-4">
+                                    @foreach ($allContributors as $contributor)
+                                        <flux:tooltip :content="'@' . $contributor->login">
+                                            <a
+                                                href="{{ $contributor->profileUrl() }}"
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                class="inline-block"
+                                            >
+                                                <img
+                                                    src="{{ $contributor->avatar }}"
+                                                    alt="{{ $contributor->login }}"
+                                                    loading="lazy"
+                                                    class="size-8 rounded-full ring-1 ring-gray-200 transition hover:ring-primary-500 dark:ring-white/10"
+                                                />
+                                            </a>
+                                        </flux:tooltip>
+                                    @endforeach
+                                </div>
+                            </div>
+                        </div>
+                    </aside>
+                @endif
+            </div>
+        @endif
+    </x-container>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,6 +36,9 @@ Route::get('subscriptions/{subscription}/unsubscribe', [SubscriptionController::
 Route::get('subscribeable/{id}/{type}', [SubscriptionController::class, 'redirect'])->name('subscriptions.redirect');
 
 Route::get('sponsors', Pages\Sponsoring::class)->name('sponsors');
+Route::get('changelog', Pages\Changelog::class)
+    ->middleware('throttle:60,1')
+    ->name('changelog');
 Route::get('callback-payment', NotchPayCallBackController::class)->name('notchpay-callback');
 
 Route::middleware(['auth', 'checkIfBanned', 'verified'])->group(function (): void {

--- a/tests/Feature/Actions/GetGithubContributorsActionTest.php
+++ b/tests/Feature/Actions/GetGithubContributorsActionTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\GetGithubContributorsAction;
+use App\Data\ContributorData;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+describe(GetGithubContributorsAction::class, function (): void {
+    beforeEach(function (): void {
+        Cache::flush();
+    });
+
+    it('fetches and hydrates all contributors from github', function (): void {
+        Http::fake([
+            'api.github.com/repos/laravelcm/laravel.cm/contributors*' => Http::response([
+                ['login' => 'mckenziearts', 'avatar_url' => 'https://avatars.githubusercontent.com/u/1?v=4'],
+                ['login' => 'johndoe', 'avatar_url' => 'https://avatars.githubusercontent.com/u/2?v=4'],
+            ]),
+        ]);
+
+        $contributors = resolve(GetGithubContributorsAction::class)();
+
+        expect($contributors)->toHaveCount(2)
+            ->and($contributors->first())->toBeInstanceOf(ContributorData::class)
+            ->and($contributors->first()->login)->toBe('mckenziearts')
+            ->and($contributors->first()->avatar)->toBe('https://unavatar.io/github/mckenziearts');
+    });
+
+    it('filters out bots', function (): void {
+        Http::fake([
+            'api.github.com/repos/laravelcm/laravel.cm/contributors*' => Http::response([
+                ['login' => 'mckenziearts', 'avatar_url' => 'https://avatars.githubusercontent.com/u/1?v=4'],
+                ['login' => 'dependabot[bot]', 'avatar_url' => 'https://avatars.githubusercontent.com/in/29110?v=4'],
+                ['login' => 'github-actions[bot]', 'avatar_url' => 'https://avatars.githubusercontent.com/in/15368?v=4'],
+                ['login' => 'johndoe', 'avatar_url' => 'https://avatars.githubusercontent.com/u/2?v=4'],
+            ]),
+        ]);
+
+        $contributors = resolve(GetGithubContributorsAction::class)();
+
+        expect($contributors)->toHaveCount(2)
+            ->and($contributors->pluck('login')->all())->toBe(['mckenziearts', 'johndoe']);
+    });
+
+    it('caches results and does not hit github twice', function (): void {
+        Http::fake([
+            'api.github.com/repos/laravelcm/laravel.cm/contributors*' => Http::response([
+                ['login' => 'mckenziearts', 'avatar_url' => 'https://avatars.githubusercontent.com/u/1?v=4'],
+            ]),
+        ]);
+
+        resolve(GetGithubContributorsAction::class)();
+        resolve(GetGithubContributorsAction::class)();
+
+        Http::assertSentCount(1);
+    });
+
+    it('returns empty collection on api failure', function (): void {
+        Http::fake([
+            'api.github.com/repos/laravelcm/laravel.cm/contributors*' => Http::response([], 500),
+        ]);
+
+        $contributors = resolve(GetGithubContributorsAction::class)();
+
+        expect($contributors)->toBeEmpty();
+    });
+});

--- a/tests/Feature/Actions/GetGithubContributorsActionTest.php
+++ b/tests/Feature/Actions/GetGithubContributorsActionTest.php
@@ -25,7 +25,7 @@ describe(GetGithubContributorsAction::class, function (): void {
         expect($contributors)->toHaveCount(2)
             ->and($contributors->first())->toBeInstanceOf(ContributorData::class)
             ->and($contributors->first()->login)->toBe('mckenziearts')
-            ->and($contributors->first()->avatar)->toBe('https://unavatar.io/github/mckenziearts');
+            ->and($contributors->first()->avatar)->toBe('https://avatars.githubusercontent.com/u/1?v=4');
     });
 
     it('filters out bots', function (): void {

--- a/tests/Feature/Actions/GetGithubReleasesActionTest.php
+++ b/tests/Feature/Actions/GetGithubReleasesActionTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\GetGithubReleasesAction;
+use App\Data\ReleaseData;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+describe(GetGithubReleasesAction::class, function (): void {
+    beforeEach(function (): void {
+        Cache::flush();
+    });
+
+    it('fetches published releases from github and hydrates them into release data', function (): void {
+        Http::fake([
+            'api.github.com/*' => Http::response([
+                [
+                    'tag_name' => 'v3.6.0',
+                    'name' => 'v3.6.0: Laravel 13 Upgrade',
+                    'body' => '## Highlights',
+                    'html_url' => 'https://github.com/laravelcm/laravel.cm/releases/tag/v3.6.0',
+                    'published_at' => '2026-04-17T06:42:54Z',
+                    'draft' => false,
+                    'prerelease' => false,
+                    'author' => [
+                        'login' => 'mckenziearts',
+                        'avatar_url' => 'https://avatars.githubusercontent.com/u/1?v=4',
+                        'html_url' => 'https://github.com/mckenziearts',
+                    ],
+                ],
+            ]),
+        ]);
+
+        $releases = resolve(GetGithubReleasesAction::class)();
+
+        expect($releases)->toHaveCount(1)
+            ->and($releases->first())->toBeInstanceOf(ReleaseData::class)
+            ->and($releases->first()->tag_name)->toBe('v3.6.0')
+            ->and($releases->first()->author->login)->toBe('mckenziearts');
+    });
+
+    it('filters out draft releases', function (): void {
+        Http::fake([
+            'api.github.com/*' => Http::response([
+                [
+                    'tag_name' => 'v3.6.0',
+                    'name' => 'v3.6.0',
+                    'body' => '...',
+                    'html_url' => 'https://github.com/laravelcm/laravel.cm/releases/tag/v3.6.0',
+                    'published_at' => '2026-04-17T06:42:54Z',
+                    'draft' => false,
+                    'prerelease' => false,
+                    'author' => [
+                        'login' => 'mckenziearts',
+                        'avatar_url' => 'https://avatars.githubusercontent.com/u/1?v=4',
+                        'html_url' => 'https://github.com/mckenziearts',
+                    ],
+                ],
+                [
+                    'tag_name' => 'v4.0.0-draft',
+                    'name' => 'Draft',
+                    'body' => '',
+                    'html_url' => 'https://github.com/laravelcm/laravel.cm/releases/tag/v4.0.0-draft',
+                    'published_at' => '2026-04-17T06:42:54Z',
+                    'draft' => true,
+                    'prerelease' => false,
+                    'author' => [
+                        'login' => 'mckenziearts',
+                        'avatar_url' => 'https://avatars.githubusercontent.com/u/1?v=4',
+                        'html_url' => 'https://github.com/mckenziearts',
+                    ],
+                ],
+            ]),
+        ]);
+
+        $releases = resolve(GetGithubReleasesAction::class)();
+
+        expect($releases)->toHaveCount(1)
+            ->and($releases->first()->tag_name)->toBe('v3.6.0');
+    });
+
+    it('caches results and does not hit github twice', function (): void {
+        Http::fake([
+            'api.github.com/*' => Http::response([
+                [
+                    'tag_name' => 'v3.6.0',
+                    'name' => 'v3.6.0',
+                    'body' => '...',
+                    'html_url' => 'https://github.com/laravelcm/laravel.cm/releases/tag/v3.6.0',
+                    'published_at' => '2026-04-17T06:42:54Z',
+                    'draft' => false,
+                    'prerelease' => false,
+                    'author' => [
+                        'login' => 'mckenziearts',
+                        'avatar_url' => 'https://avatars.githubusercontent.com/u/1?v=4',
+                        'html_url' => 'https://github.com/mckenziearts',
+                    ],
+                ],
+            ]),
+        ]);
+
+        resolve(GetGithubReleasesAction::class)();
+        resolve(GetGithubReleasesAction::class)();
+
+        Http::assertSentCount(1);
+    });
+
+    it('returns empty collection on api failure', function (): void {
+        Http::fake([
+            'api.github.com/*' => Http::response([], 500),
+        ]);
+
+        $releases = resolve(GetGithubReleasesAction::class)();
+
+        expect($releases)->toBeEmpty();
+    });
+});

--- a/tests/Feature/HelpersTest.php
+++ b/tests/Feature/HelpersTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\URL;
+
+describe('safe_previous_url', function (): void {
+    beforeEach(function (): void {
+        config(['app.url' => 'https://laravel.cm']);
+    });
+
+    it('returns the previous url when it is same-origin', function (): void {
+        URL::getRequest()->headers->set('referer', 'https://laravel.cm/articles');
+
+        expect(safe_previous_url())->toBe('https://laravel.cm/articles');
+    });
+
+    it('returns the home route when the previous url is on a different host', function (): void {
+        URL::getRequest()->headers->set('referer', 'https://evil.com/phishing');
+
+        expect(safe_previous_url())->toBe(route('home'));
+    });
+
+    it('returns the home route when no previous url is available', function (): void {
+        $request = Request::create('/current-page', 'GET');
+        app()->instance('request', $request);
+        URL::setRequest($request);
+
+        expect(safe_previous_url())->toBe(route('home'));
+    });
+
+    it('returns a provided fallback instead of home when the previous url is off-site', function (): void {
+        URL::getRequest()->headers->set('referer', 'https://evil.com/attack');
+
+        expect(safe_previous_url('https://laravel.cm/fallback'))->toBe('https://laravel.cm/fallback');
+    });
+
+    it('does not leak if the previous url is malformed', function (): void {
+        URL::getRequest()->headers->set('referer', '///no-host-here');
+
+        expect(safe_previous_url())->toBe(route('home'));
+    });
+
+    it('rejects previous urls that share a suffix with the app host', function (): void {
+        URL::getRequest()->headers->set('referer', 'https://fake-laravel.cm/');
+
+        expect(safe_previous_url())->toBe(route('home'));
+    });
+});

--- a/tests/Feature/Livewire/Pages/ChangelogTest.php
+++ b/tests/Feature/Livewire/Pages/ChangelogTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\Pages\Changelog;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Livewire\Livewire;
+
+describe(Changelog::class, function (): void {
+    beforeEach(function (): void {
+        Cache::flush();
+    });
+
+    it('renders the changelog page with releases from github', function (): void {
+        Http::fake([
+            'api.github.com/repos/laravelcm/laravel.cm/releases*' => Http::response([
+                [
+                    'tag_name' => 'v3.6.0',
+                    'name' => 'v3.6.0: Laravel 13 Upgrade',
+                    'body' => '## Highlights'.PHP_EOL.PHP_EOL.'Shipped in #527.',
+                    'html_url' => 'https://github.com/laravelcm/laravel.cm/releases/tag/v3.6.0',
+                    'published_at' => '2026-04-17T06:42:54Z',
+                    'draft' => false,
+                    'prerelease' => false,
+                    'author' => [
+                        'login' => 'mckenziearts',
+                        'avatar_url' => 'https://avatars.githubusercontent.com/u/1?v=4',
+                        'html_url' => 'https://github.com/mckenziearts',
+                    ],
+                ],
+            ]),
+            'api.github.com/repos/laravelcm/laravel.cm/contributors*' => Http::response([
+                ['login' => 'mckenziearts', 'avatar_url' => 'https://avatars.githubusercontent.com/u/1?v=4'],
+            ]),
+        ]);
+
+        Livewire::test(Changelog::class)
+            ->assertOk()
+            ->assertSee('v3.6.0')
+            ->assertSee('Laravel 13 Upgrade')
+            ->assertSee(__('pages/changelog.all_contributors'));
+    });
+
+    it('renders the empty state when no releases are returned', function (): void {
+        Http::fake([
+            'api.github.com/*' => Http::response([]),
+        ]);
+
+        Livewire::test(Changelog::class)
+            ->assertOk()
+            ->assertSee(__('pages/changelog.empty'));
+    });
+
+    it('renders all project contributors in the sticky aside', function (): void {
+        Http::fake([
+            'api.github.com/repos/laravelcm/laravel.cm/releases*' => Http::response([
+                [
+                    'tag_name' => 'v3.6.0',
+                    'name' => 'v3.6.0',
+                    'body' => '',
+                    'html_url' => 'https://github.com/laravelcm/laravel.cm/releases/tag/v3.6.0',
+                    'published_at' => '2026-04-17T06:42:54Z',
+                    'draft' => false,
+                    'prerelease' => false,
+                    'author' => [
+                        'login' => 'mckenziearts',
+                        'avatar_url' => 'https://avatars.githubusercontent.com/u/1?v=4',
+                        'html_url' => 'https://github.com/mckenziearts',
+                    ],
+                ],
+            ]),
+            'api.github.com/repos/laravelcm/laravel.cm/contributors*' => Http::response([
+                ['login' => 'mckenziearts', 'avatar_url' => 'https://avatars.githubusercontent.com/u/1?v=4'],
+                ['login' => 'contributorone', 'avatar_url' => 'https://avatars.githubusercontent.com/u/2?v=4'],
+                ['login' => 'contributortwo', 'avatar_url' => 'https://avatars.githubusercontent.com/u/3?v=4'],
+            ]),
+        ]);
+
+        Livewire::test(Changelog::class)
+            ->assertOk()
+            ->assertSee(__('pages/changelog.all_contributors'))
+            ->assertSee('https://github.com/contributorone')
+            ->assertSee('https://github.com/contributortwo');
+    });
+
+    it('transforms pr references in release body into github links', function (): void {
+        $component = new Changelog;
+
+        $html = $component->renderBody('Shipped in #527 and #528.');
+
+        expect($html)
+            ->toContain('href="https://github.com/laravelcm/laravel.cm/pull/527"')
+            ->and($html)->toContain('>#527</a>')
+            ->and($html)->toContain('href="https://github.com/laravelcm/laravel.cm/pull/528"');
+    });
+
+    it('strips unsafe url schemes from release body links', function (): void {
+        $component = new Changelog;
+
+        $html = $component->renderBody('[click me](javascript:alert(1)) and [data](data:text/html,<script>alert(1)</script>)');
+
+        expect($html)
+            ->not->toContain('javascript:')
+            ->and($html)->not->toContain('data:text/html');
+    });
+
+    it('adds noopener, noreferrer and nofollow on external links from release body', function (): void {
+        $component = new Changelog;
+
+        $html = $component->renderBody('Visit [laravel.cm](https://laravel.cm) for more.');
+
+        expect($html)
+            ->toContain('target="_blank"')
+            ->and($html)->toContain('noopener')
+            ->and($html)->toContain('noreferrer')
+            ->and($html)->toContain('nofollow');
+    });
+
+    it('does not double-wrap anchors that already have target or rel attributes', function (): void {
+        $component = new Changelog;
+
+        $html = $component->renderBody('See #527 and #528.');
+
+        // PR references generate their own <a> with target/rel; the
+        // enrichment pass must not double-insert those attributes.
+        expect(mb_substr_count($html, 'target="_blank"'))->toBe(2)
+            ->and(mb_substr_count($html, 'noreferrer'))->toBe(2);
+    });
+
+    it('is reachable via the named route', function (): void {
+        Http::fake([
+            'api.github.com/*' => Http::response([]),
+        ]);
+
+        $this->get(route('changelog'))->assertOk();
+    });
+});

--- a/tests/Feature/Livewire/Pages/ChangelogTest.php
+++ b/tests/Feature/Livewire/Pages/ChangelogTest.php
@@ -84,50 +84,6 @@ describe(Changelog::class, function (): void {
             ->assertSee('https://github.com/contributortwo');
     });
 
-    it('transforms pr references in release body into github links', function (): void {
-        $component = new Changelog;
-
-        $html = $component->renderBody('Shipped in #527 and #528.');
-
-        expect($html)
-            ->toContain('href="https://github.com/laravelcm/laravel.cm/pull/527"')
-            ->and($html)->toContain('>#527</a>')
-            ->and($html)->toContain('href="https://github.com/laravelcm/laravel.cm/pull/528"');
-    });
-
-    it('strips unsafe url schemes from release body links', function (): void {
-        $component = new Changelog;
-
-        $html = $component->renderBody('[click me](javascript:alert(1)) and [data](data:text/html,<script>alert(1)</script>)');
-
-        expect($html)
-            ->not->toContain('javascript:')
-            ->and($html)->not->toContain('data:text/html');
-    });
-
-    it('adds noopener, noreferrer and nofollow on external links from release body', function (): void {
-        $component = new Changelog;
-
-        $html = $component->renderBody('Visit [laravel.cm](https://laravel.cm) for more.');
-
-        expect($html)
-            ->toContain('target="_blank"')
-            ->and($html)->toContain('noopener')
-            ->and($html)->toContain('noreferrer')
-            ->and($html)->toContain('nofollow');
-    });
-
-    it('does not double-wrap anchors that already have target or rel attributes', function (): void {
-        $component = new Changelog;
-
-        $html = $component->renderBody('See #527 and #528.');
-
-        // PR references generate their own <a> with target/rel; the
-        // enrichment pass must not double-insert those attributes.
-        expect(mb_substr_count($html, 'target="_blank"'))->toBe(2)
-            ->and(mb_substr_count($html, 'noreferrer'))->toBe(2);
-    });
-
     it('is reachable via the named route', function (): void {
         Http::fake([
             'api.github.com/*' => Http::response([]),

--- a/tests/Feature/Services/ReleaseBodyRendererTest.php
+++ b/tests/Feature/Services/ReleaseBodyRendererTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\ReleaseBodyRenderer;
+
+describe(ReleaseBodyRenderer::class, function (): void {
+    beforeEach(function (): void {
+        $this->renderer = new ReleaseBodyRenderer('https://github.com/laravelcm/laravel.cm');
+    });
+
+    it('renders markdown to html', function (): void {
+        $html = $this->renderer->render('## Heading');
+
+        expect($html)->toContain('<h2>')
+            ->and($html)->toContain('Heading');
+    });
+
+    it('strips javascript url scheme from links', function (): void {
+        $html = $this->renderer->render('[click](javascript:alert(1))');
+
+        expect($html)->not->toContain('javascript:');
+    });
+
+    it('strips data and vbscript url schemes from links', function (): void {
+        $html = $this->renderer->render(
+            '[a](data:text/html,<script>alert(1)</script>) and [b](vbscript:msg)'
+        );
+
+        expect($html)
+            ->not->toContain('data:text/html')
+            ->and($html)->not->toContain('vbscript:');
+    });
+
+    it('adds target, noopener, noreferrer and nofollow on external https links', function (): void {
+        $html = $this->renderer->render('Visit [laravel.cm](https://laravel.cm)');
+
+        expect($html)
+            ->toContain('target="_blank"')
+            ->and($html)->toContain('noopener')
+            ->and($html)->toContain('noreferrer')
+            ->and($html)->toContain('nofollow');
+    });
+
+    it('does not modify relative anchors', function (): void {
+        $html = $this->renderer->render('[jump](#section)');
+
+        expect($html)->not->toContain('target="_blank"');
+    });
+
+    it('linkifies pull request references', function (): void {
+        $html = $this->renderer->render('Shipped in #527.');
+
+        expect($html)
+            ->toContain('href="https://github.com/laravelcm/laravel.cm/pull/527"')
+            ->and($html)->toContain('>#527</a>');
+    });
+
+    it('does not double-wrap anchors when both a link and a pr reference are present', function (): void {
+        $html = $this->renderer->render('See [docs](https://laravel.cm/docs) and #527.');
+
+        expect(mb_substr_count($html, 'target="_blank"'))->toBe(2)
+            ->and(mb_substr_count($html, 'noreferrer'))->toBe(2);
+    });
+
+    it('uses the configured repository url for pr references', function (): void {
+        $customRenderer = new ReleaseBodyRenderer('https://github.com/custom/repo');
+
+        $html = $customRenderer->render('See #42.');
+
+        expect($html)->toContain('https://github.com/custom/repo/pull/42');
+    });
+});

--- a/tests/Feature/Spotlight/Commands/GoToChangelogTest.php
+++ b/tests/Feature/Spotlight/Commands/GoToChangelogTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\Components\Spotlight;
+use App\Spotlight\Commands\GoToChangelog;
+use Livewire\Livewire;
+
+describe(GoToChangelog::class, function (): void {
+    it('exposes the translated name', function (): void {
+        $command = new GoToChangelog;
+
+        expect($command->getName())->toBe(__('global.navigation.changelog'));
+    });
+
+    it('navigates to the changelog route when executed via spotlight', function (): void {
+        Livewire::test(Spotlight::class)
+            ->call('executeCommand', (new GoToChangelog)->getId())
+            ->assertRedirect(route('changelog'));
+    });
+});

--- a/tests/Feature/Spotlight/Commands/ToggleLocaleTest.php
+++ b/tests/Feature/Spotlight/Commands/ToggleLocaleTest.php
@@ -37,4 +37,14 @@ describe(ToggleLocale::class, function (): void {
 
         expect(session('locale'))->toBe('fr');
     });
+
+    it('refuses to redirect to an external url when the referer is hostile', function (): void {
+        config(['app.url' => 'https://laravel.cm']);
+        app()->setLocale('fr');
+
+        Livewire::withHeaders(['Referer' => 'https://evil.com/phishing'])
+            ->test(Spotlight::class)
+            ->call('executeCommand', (new ToggleLocale)->getId())
+            ->assertRedirect(route('home'));
+    });
 });

--- a/tests/Feature/Spotlight/Commands/ToggleLocaleTest.php
+++ b/tests/Feature/Spotlight/Commands/ToggleLocaleTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\Components\Spotlight;
+use App\Models\User;
+use App\Spotlight\Commands\ToggleLocale;
+use Livewire\Livewire;
+
+describe(ToggleLocale::class, function (): void {
+    it('stores the new locale in session for guests', function (): void {
+        app()->setLocale('fr');
+
+        Livewire::test(Spotlight::class)
+            ->call('executeCommand', (new ToggleLocale)->getId());
+
+        expect(session('locale'))->toBe('en');
+    });
+
+    it('persists the new locale in user settings when authenticated', function (): void {
+        $user = User::factory()->create(['settings' => ['locale' => 'fr']]);
+        $this->actingAs($user);
+        app()->setLocale('fr');
+
+        Livewire::test(Spotlight::class)
+            ->call('executeCommand', (new ToggleLocale)->getId());
+
+        expect($user->fresh()->setting('locale'))->toBe('en')
+            ->and(session('locale'))->toBe('en');
+    });
+
+    it('toggles back from en to fr', function (): void {
+        app()->setLocale('en');
+
+        Livewire::test(Spotlight::class)
+            ->call('executeCommand', (new ToggleLocale)->getId());
+
+        expect(session('locale'))->toBe('fr');
+    });
+});


### PR DESCRIPTION
## Summary

New `/changelog` page listing the 10 latest GitHub releases in a Linear-inspired timeline, with a page-level sticky sidebar on the right showing every contributor to the project since day one.

## What's in

### Page `/changelog`
- Timeline layout: date column (sticky per release) + content column
- Each release shows: version badge (linked to GitHub release), title, rendered markdown body, and contributors who shipped it
- Right sidebar: all project contributors (via `/repos/:owner/:repo/contributors`) with `flux:tooltip` on hover, sticky at the page level
- Empty state when GitHub is unreachable

### Caching strategy
- Releases: `Cache::flexible` **3 days fresh / 5 days SWR**
- Contributors: `Cache::flexible` **7 days fresh / 14 days SWR**
- Degrades silently on API failure (returns empty collection, logs a warning)

### Security (XSS-hardened rendering)
- Markdown body goes through `md_to_html` then:
  - Strip `javascript:`, `data:`, `vbscript:` URL schemes
  - Force `target="_blank" rel="noopener noreferrer nofollow"` on every external `<a>`
  - Linkify `#PR` references to the matching pull request
- Route rate-limited: `throttle:60,1`

### Spotlight
- `GoToChangelog` — navigation command (Cmd+K → "changelog", "release", "mises à jour", …)
- `ToggleLocale` — language switch command next to the theme toggle; persists in `user->settings['locale']` when authenticated, falls back to session otherwise (reuses existing `LocaleMiddleware` logic)

### Footer
Link added under Resources, right after "About".

## Tests

`composer test:types` → **OK, no errors**
`php artisan test --filter="Changelog|GetGithubReleases|GetGithubContributors|Spotlight"` → **38 passed**

- 4 tests on `GetGithubReleasesAction` (hydration, drafts filtered, cache, fallback)
- 4 tests on `GetGithubContributorsAction` (hydration, bots filtered, cache, fallback)
- 8 tests on `Changelog` Livewire component (render, empty state, contributors sidebar, XSS hardening, PR linkification, route reachability)

## Deployment

No migration, no config change. The page is public and immediately available after merge. GitHub token is already configured via `GITHUB_FINE_GRAINED_TOKEN` (used for higher API rate limits — the action also works anonymously).
